### PR TITLE
Transferring postTasks() from Go to SQL database

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For all commands,
 
 `<Title>` is a `string` value
 
-`<Complete>` is a `boolen` value
+`<Complete>` is a `boolean` value
 
 
 ### Get health:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For all commands,
         --include \
         --header "Content-Type: application/json" \
         --request "POST" \
-        --data '{"ID": <ID>,"Title": "<Title>", "Complete": <Complete>}'
+        --data '{"Title": "<Title>", "Complete": <Complete>}'
 
 ### Put task at ID:
     curl http://localhost:8080/tasks/<ID> \

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16,37 +16,7 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/health": {
-            "get": {
-                "description": "Returns the health of the server - currently hardcoded to \"OK\"",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "getHealth",
-                "responses": {}
-            }
-        },
         "/tasks": {
-            "get": {
-                "description": "Gets all tasks in database",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "getTasks",
-                "responses": {}
-            },
             "post": {
                 "description": "Adds new task at the end of database",
                 "consumes": [
@@ -72,86 +42,6 @@ const docTemplate = `{
                 ],
                 "responses": {}
             }
-        },
-        "/tasks/{id}": {
-            "get": {
-                "description": "Gets all tasks with specified ID",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "getTaskByID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "The specified ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            },
-            "put": {
-                "description": "Adds new task at the specified ID, or end of database if ID can't be found",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "putTasks",
-                "parameters": [
-                    {
-                        "description": "The task to add",
-                        "name": "task",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.Task"
-                        }
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The specified ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            },
-            "delete": {
-                "description": "Deletes tast at specified ID",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "deleteTask",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "The specified ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            }
         }
     },
     "definitions": {
@@ -160,6 +50,9 @@ const docTemplate = `{
             "properties": {
                 "complete": {
                     "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
                 },
                 "title": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -159,10 +159,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "complete": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
+                    "type": "boolean"
                 },
                 "title": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12,37 +12,7 @@
     "host": "localhost:8080",
     "basePath": "/",
     "paths": {
-        "/health": {
-            "get": {
-                "description": "Returns the health of the server - currently hardcoded to \"OK\"",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "getHealth",
-                "responses": {}
-            }
-        },
         "/tasks": {
-            "get": {
-                "description": "Gets all tasks in database",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "getTasks",
-                "responses": {}
-            },
             "post": {
                 "description": "Adds new task at the end of database",
                 "consumes": [
@@ -68,86 +38,6 @@
                 ],
                 "responses": {}
             }
-        },
-        "/tasks/{id}": {
-            "get": {
-                "description": "Gets all tasks with specified ID",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "getTaskByID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "The specified ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            },
-            "put": {
-                "description": "Adds new task at the specified ID, or end of database if ID can't be found",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "putTasks",
-                "parameters": [
-                    {
-                        "description": "The task to add",
-                        "name": "task",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.Task"
-                        }
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The specified ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            },
-            "delete": {
-                "description": "Deletes tast at specified ID",
-                "consumes": [
-                    "*/*"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "root"
-                ],
-                "summary": "deleteTask",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "The specified ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            }
         }
     },
     "definitions": {
@@ -156,6 +46,9 @@
             "properties": {
                 "complete": {
                     "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
                 },
                 "title": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -155,10 +155,7 @@
             "type": "object",
             "properties": {
                 "complete": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
+                    "type": "boolean"
                 },
                 "title": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,9 +3,7 @@ definitions:
   main.Task:
     properties:
       complete:
-        type: string
-      id:
-        type: integer
+        type: boolean
       title:
         type: string
     type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,6 +4,8 @@ definitions:
     properties:
       complete:
         type: boolean
+      id:
+        type: integer
       title:
         type: string
     type: object
@@ -14,28 +16,7 @@ info:
   title: Gin Swagger todo-list API
   version: "1.0"
 paths:
-  /health:
-    get:
-      consumes:
-      - '*/*'
-      description: Returns the health of the server - currently hardcoded to "OK"
-      produces:
-      - application/json
-      responses: {}
-      summary: getHealth
-      tags:
-      - root
   /tasks:
-    get:
-      consumes:
-      - '*/*'
-      description: Gets all tasks in database
-      produces:
-      - application/json
-      responses: {}
-      summary: getTasks
-      tags:
-      - root
     post:
       consumes:
       - '*/*'
@@ -51,62 +32,6 @@ paths:
       - application/json
       responses: {}
       summary: postTasks
-      tags:
-      - root
-  /tasks/{id}:
-    delete:
-      consumes:
-      - '*/*'
-      description: Deletes tast at specified ID
-      parameters:
-      - description: The specified ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses: {}
-      summary: deleteTask
-      tags:
-      - root
-    get:
-      consumes:
-      - '*/*'
-      description: Gets all tasks with specified ID
-      parameters:
-      - description: The specified ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses: {}
-      summary: getTaskByID
-      tags:
-      - root
-    put:
-      consumes:
-      - '*/*'
-      description: Adds new task at the specified ID, or end of database if ID can't
-        be found
-      parameters:
-      - description: The task to add
-        in: body
-        name: task
-        required: true
-        schema:
-          $ref: '#/definitions/main.Task'
-      - description: The specified ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses: {}
-      summary: putTasks
       tags:
       - root
 schemes:

--- a/handler.go
+++ b/handler.go
@@ -15,7 +15,7 @@ import (
 // @Produce json
 // @Router /health [get]
 func getHealth(c *gin.Context) {
-	c.IndentedJSON(http.StatusOK, "OK")
+	// c.IndentedJSON(http.StatusOK, "OK")
 }
 
 // getTasks godoc
@@ -26,7 +26,7 @@ func getHealth(c *gin.Context) {
 // @Produce json
 // @Router /tasks [get]
 func getTasks(c *gin.Context) {
-	c.IndentedJSON(http.StatusOK, tasks)
+	// c.IndentedJSON(http.StatusOK, tasks)
 }
 
 // getTaskByID godoc
@@ -38,17 +38,21 @@ func getTasks(c *gin.Context) {
 // @Produce json
 // @Router /tasks/{id} [get]
 func getTaskByID(c *gin.Context) {
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return
-	}
+	// 	var taskToSearch Task
 
-	foundTask, foundErr := getTaskByID_sql(id)
-	if foundErr != nil {
-		c.IndentedJSON(http.StatusNotFound, foundErr)
-		return
-	}
-	c.IndentedJSON(http.StatusOK, foundTask)
+	// 	if err := c.BindJSON(&taskToSearch); err != nil {
+	// 		c.IndentedJSON(http.StatusBadRequest, err)
+	// 		return
+	// 	}
+
+	// foundTask, foundErr := getTaskByID_sql(taskToSearch)
+	//
+	//	if foundErr != nil {
+	//		c.IndentedJSON(http.StatusNotFound, foundErr)
+	//		return
+	//	}
+	//
+	// c.IndentedJSON(http.StatusOK, foundTask)
 }
 
 // postTasks godoc
@@ -64,16 +68,18 @@ func postTask(c *gin.Context) {
 	var newTask Task
 
 	if err := c.BindJSON(&newTask); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, err)
 		return
 	}
 
-	newTaskID, err := postTask_sql(newTask)
+	newID, err := postTask_sql(newTask)
 	if err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err)
 		return
 	}
-	c.IndentedJSON(http.StatusCreated, newTaskID)
 
+	result := "Task created: " + newTask.Title + " at ID " + strconv.Itoa(int(newID))
+	c.IndentedJSON(http.StatusCreated, result)
 }
 
 // putTasks godoc
@@ -87,25 +93,25 @@ func postTask(c *gin.Context) {
 // @Produce json
 // @Router /tasks/{id} [PUT]
 func putTasks(c *gin.Context) {
-	var newTask Task
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return
-	}
+	// var newTask Task
+	// id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	// if err != nil {
+	// 	return
+	// }
 
-	if err := c.BindJSON(&newTask); err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"Error": "could not bind JSON"})
-	}
+	// if err := c.BindJSON(&newTask); err != nil {
+	// 	c.IndentedJSON(http.StatusBadRequest, gin.H{"Error": "could not bind JSON"})
+	// }
 
-	for i := 0; i < len(tasks); i++ {
-		if tasks[i].ID == id {
-			tasks[i] = newTask
-			c.IndentedJSON(http.StatusOK, newTask)
-			return
-		}
-	}
-	tasks = append(tasks, newTask)
-	c.IndentedJSON(http.StatusCreated, newTask)
+	// for i := 0; i < len(tasks); i++ {
+	// 	if tasks[i].ID == id {
+	// 		tasks[i] = newTask
+	// 		c.IndentedJSON(http.StatusOK, newTask)
+	// 		return
+	// 	}
+	// }
+	// tasks = append(tasks, newTask)
+	// c.IndentedJSON(http.StatusCreated, newTask)
 }
 
 // deleteTask godoc
@@ -117,19 +123,19 @@ func putTasks(c *gin.Context) {
 // @Produce json
 // @Router /tasks/{id} [DELETE]
 func deleteTask(c *gin.Context) {
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return
-	}
+	// id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	// if err != nil {
+	// 	return
+	// }
 
-	for i := 0; i < len(tasks); i++ {
-		if tasks[i].ID == id {
-			firstHalf := tasks[0:i]
-			secondHalf := tasks[i+1:]
-			tasks = append(firstHalf, secondHalf...)
-			c.IndentedJSON(http.StatusOK, tasks)
-			return
-		}
-	}
-	c.IndentedJSON(http.StatusNotFound, gin.H{"Error": "ID not found"})
+	// for i := 0; i < len(tasks); i++ {
+	// 	if tasks[i].ID == id {
+	// 		firstHalf := tasks[0:i]
+	// 		secondHalf := tasks[i+1:]
+	// 		tasks = append(firstHalf, secondHalf...)
+	// 		c.IndentedJSON(http.StatusOK, tasks)
+	// 		return
+	// 	}
+	// }
+	// c.IndentedJSON(http.StatusNotFound, gin.H{"Error": "ID not found"})
 }

--- a/handler.go
+++ b/handler.go
@@ -7,55 +7,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// getHealth godoc
-// @Summary getHealth
-// @Description Returns the health of the server - currently hardcoded to "OK"
-// @Tags root
-// @Accept */*
-// @Produce json
-// @Router /health [get]
+// TODO: Implement getHealth
 func getHealth(c *gin.Context) {
-	// c.IndentedJSON(http.StatusOK, "OK")
 }
 
-// getTasks godoc
-// @Summary getTasks
-// @Description Gets all tasks in database
-// @Tags root
-// @Accept */*
-// @Produce json
-// @Router /tasks [get]
+// TODO: Implement getTasks
 func getTasks(c *gin.Context) {
-	// c.IndentedJSON(http.StatusOK, tasks)
 }
 
-// getTaskByID godoc
-// @Summary getTaskByID
-// @Description Gets all tasks with specified ID
-// @Tags root
-// @Param id path int true "The specified ID"
-// @Accept */*
-// @Produce json
-// @Router /tasks/{id} [get]
+// TODO: Implement getTasksByID
 func getTaskByID(c *gin.Context) {
-	// 	var taskToSearch Task
-
-	// 	if err := c.BindJSON(&taskToSearch); err != nil {
-	// 		c.IndentedJSON(http.StatusBadRequest, err)
-	// 		return
-	// 	}
-
-	// foundTask, foundErr := getTaskByID_sql(taskToSearch)
-	//
-	//	if foundErr != nil {
-	//		c.IndentedJSON(http.StatusNotFound, foundErr)
-	//		return
-	//	}
-	//
-	// c.IndentedJSON(http.StatusOK, foundTask)
 }
 
-// postTasks godoc
+// TODO: add func getTasksByComplete
+
+// postTask godoc
 // @Summary postTasks
 // @Description Adds new task at the end of database
 // @Tags root
@@ -82,60 +48,10 @@ func postTask(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, result)
 }
 
-// putTasks godoc
-// @Summary putTasks
-// @Description Adds new task at the specified ID, or end of database if ID can't be found
-// @Tags root
-// @RequestBody required
-// @Param task body Task true "The task to add"
-// @Param id path int true "The specified ID"
-// @Accept */*
-// @Produce json
-// @Router /tasks/{id} [PUT]
+// TODO: Implement putTasks
 func putTasks(c *gin.Context) {
-	// var newTask Task
-	// id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	// if err != nil {
-	// 	return
-	// }
-
-	// if err := c.BindJSON(&newTask); err != nil {
-	// 	c.IndentedJSON(http.StatusBadRequest, gin.H{"Error": "could not bind JSON"})
-	// }
-
-	// for i := 0; i < len(tasks); i++ {
-	// 	if tasks[i].ID == id {
-	// 		tasks[i] = newTask
-	// 		c.IndentedJSON(http.StatusOK, newTask)
-	// 		return
-	// 	}
-	// }
-	// tasks = append(tasks, newTask)
-	// c.IndentedJSON(http.StatusCreated, newTask)
 }
 
-// deleteTask godoc
-// @Summary deleteTask
-// @Description Deletes tast at specified ID
-// @Tags root
-// @Param id path int true "The specified ID"
-// @Accept */*
-// @Produce json
-// @Router /tasks/{id} [DELETE]
+// TODO: Implement deleteTask
 func deleteTask(c *gin.Context) {
-	// id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	// if err != nil {
-	// 	return
-	// }
-
-	// for i := 0; i < len(tasks); i++ {
-	// 	if tasks[i].ID == id {
-	// 		firstHalf := tasks[0:i]
-	// 		secondHalf := tasks[i+1:]
-	// 		tasks = append(firstHalf, secondHalf...)
-	// 		c.IndentedJSON(http.StatusOK, tasks)
-	// 		return
-	// 	}
-	// }
-	// c.IndentedJSON(http.StatusNotFound, gin.H{"Error": "ID not found"})
 }

--- a/task.go
+++ b/task.go
@@ -1,13 +1,6 @@
 package main
 
 type Task struct {
-	ID       int64  `json:"id"`
 	Title    string `json:"title"`
 	Complete bool   `json:"complete"`
-}
-
-var tasks = []Task{
-	{ID: 1, Title: "Wake up", Complete: false},
-	{ID: 2, Title: "Go to work", Complete: false},
-	{ID: 3, Title: "Make dinner", Complete: false},
 }

--- a/task.go
+++ b/task.go
@@ -1,6 +1,7 @@
 package main
 
 type Task struct {
+	ID       int    `json:"id"`
 	Title    string `json:"title"`
 	Complete bool   `json:"complete"`
 }

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -1,23 +1,14 @@
 package main
 
 import (
-	// "database/sql"
 	"fmt"
 )
 
-// Returns task in SQL database with specified ID
-// func getTaskByID_sql(id int64) (Task, error) {
-// 	var tsk Task
+// TODO: add func getTasks_sql
 
-// 	row := db.QueryRow("SELECT * FROM tasks WHERE id = ?", id)
-// 	if err := row.Scan(&tsk.Title, &tsk.Complete); err != nil {
-// 		if err == sql.ErrNoRows {
-// 			return tsk, fmt.Errorf("taskByID %d: no such task", id)
-// 		}
-// 		return tsk, fmt.Errorf("taskByID %d: %v", id, err)
-// 	}
-// 	return tsk, nil
-// }
+// TODO: add func getTaskByID_sql
+
+// TODO: add func getTasksByComplete_sql
 
 // Adds task to the end of SQL database
 func postTask_sql(tsk Task) (int64, error) {
@@ -33,26 +24,6 @@ func postTask_sql(tsk Task) (int64, error) {
 	return newID, nil
 }
 
-// Returns all tasks in SQL database with specified 'complete' state
-// func tasksByComplete(complete string) ([]Task, error) {
-// var tasks []Task
+// TODO: add func putTasks_sql
 
-// rows, err := db.Query("SELECT * FROM tasks WHERE complete = ?", complete)
-// if err != nil {
-// 	return nil, fmt.Errorf("tasksByComplete %q: %v", complete, err)
-// }
-// defer rows.Close()
-
-// for rows.Next() {
-// 	var tsk Task
-// 	if err := rows.Scan(&tsk.ID, &tsk.Title, &tsk.Complete); err != nil {
-// 		return nil, fmt.Errorf("tasksByComplete %q: %v", complete, err)
-// 	}
-// 	tasks = append(tasks, tsk)
-// }
-
-// if err := rows.Err(); err != nil {
-// 	return nil, fmt.Errorf("albumsByComplete %q: %v", complete, err)
-// }
-// return tasks, nil
-// }
+// TODO: add func deleteTask_sql

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -1,58 +1,58 @@
 package main
 
 import (
-	"database/sql"
+	// "database/sql"
 	"fmt"
 )
 
+// Returns task in SQL database with specified ID
+// func getTaskByID_sql(id int64) (Task, error) {
+// 	var tsk Task
+
+// 	row := db.QueryRow("SELECT * FROM tasks WHERE id = ?", id)
+// 	if err := row.Scan(&tsk.Title, &tsk.Complete); err != nil {
+// 		if err == sql.ErrNoRows {
+// 			return tsk, fmt.Errorf("taskByID %d: no such task", id)
+// 		}
+// 		return tsk, fmt.Errorf("taskByID %d: %v", id, err)
+// 	}
+// 	return tsk, nil
+// }
+
 // Adds task to the end of SQL database
 func postTask_sql(tsk Task) (int64, error) {
-	result, err := db.Exec("INSERT INTO tasks (ID, Title, Complete) VALUES (?, ?, ?)", tsk.ID, tsk.Title, tsk.Complete)
+	result, err := db.Exec("INSERT INTO tasks (Title, Complete) VALUES (?, ?)", tsk.Title, tsk.Complete)
 	if err != nil {
-		return 0, fmt.Errorf("addTask: %v", err)
+		return 0, fmt.Errorf("error: %v", err)
 	}
 
-	id, err := result.LastInsertId()
+	newID, err := result.LastInsertId()
 	if err != nil {
-		return 0, fmt.Errorf("addTask: %v", err)
+		return 0, fmt.Errorf("error: %v", err)
 	}
-	return id, nil
+	return newID, nil
 }
 
 // Returns all tasks in SQL database with specified 'complete' state
-func tasksByComplete(complete string) ([]Task, error) {
-	var tasks []Task
+// func tasksByComplete(complete string) ([]Task, error) {
+// var tasks []Task
 
-	rows, err := db.Query("SELECT * FROM tasks WHERE complete = ?", complete)
-	if err != nil {
-		return nil, fmt.Errorf("tasksByComplete %q: %v", complete, err)
-	}
-	defer rows.Close()
+// rows, err := db.Query("SELECT * FROM tasks WHERE complete = ?", complete)
+// if err != nil {
+// 	return nil, fmt.Errorf("tasksByComplete %q: %v", complete, err)
+// }
+// defer rows.Close()
 
-	for rows.Next() {
-		var tsk Task
-		if err := rows.Scan(&tsk.ID, &tsk.Title, &tsk.Complete); err != nil {
-			return nil, fmt.Errorf("tasksByComplete %q: %v", complete, err)
-		}
-		tasks = append(tasks, tsk)
-	}
+// for rows.Next() {
+// 	var tsk Task
+// 	if err := rows.Scan(&tsk.ID, &tsk.Title, &tsk.Complete); err != nil {
+// 		return nil, fmt.Errorf("tasksByComplete %q: %v", complete, err)
+// 	}
+// 	tasks = append(tasks, tsk)
+// }
 
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("albumsByComplete %q: %v", complete, err)
-	}
-	return tasks, nil
-}
-
-// Returns task in SQL database with specified ID
-func getTaskByID_sql(id int64) (Task, error) {
-	var tsk Task
-
-	row := db.QueryRow("SELECT * FROM tasks WHERE id = ?", id)
-	if err := row.Scan(&tsk.ID, &tsk.Title, &tsk.Complete); err != nil {
-		if err == sql.ErrNoRows {
-			return tsk, fmt.Errorf("taskByID %d: no such task", id)
-		}
-		return tsk, fmt.Errorf("taskByID %d: %v", id, err)
-	}
-	return tsk, nil
-}
+// if err := rows.Err(); err != nil {
+// 	return nil, fmt.Errorf("albumsByComplete %q: %v", complete, err)
+// }
+// return tasks, nil
+// }


### PR DESCRIPTION
This branch takes the postTask() function and changes it so that it modifies the SQL database instead of modifying the "dummy" database in tasks.go. As it is the first of many transfer branches, all old functions have been commented out and will be added back as they are transferred to SQL. The updated POST command in readme calls postTasks() in handler.go and then that handler function calls the SQL-reading/writing function postTasks_sql() in tasks-repository.go. Together, they add the given task at the end of the SQL database and return the message "Task created: <task name> at ID <id>".