### PR TITLE
getTaskByID() transfer to SQL

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -31,13 +31,38 @@ const docTemplate = `{
                 "summary": "postTasks",
                 "parameters": [
                     {
-                        "description": "The task to add",
-                        "name": "task",
+                        "description": "Task to add",
+                        "name": "Task",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Task"
+                            "$ref": "#/definitions/main.shortTask"
                         }
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/tasks/{id}": {
+            "get": {
+                "description": "Gets all tasks with specified ID",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "getTaskByID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID to get",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {}
@@ -45,14 +70,11 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "main.Task": {
+        "main.shortTask": {
             "type": "object",
             "properties": {
                 "complete": {
                     "type": "boolean"
-                },
-                "id": {
-                    "type": "integer"
                 },
                 "title": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -27,13 +27,38 @@
                 "summary": "postTasks",
                 "parameters": [
                     {
-                        "description": "The task to add",
-                        "name": "task",
+                        "description": "Task to add",
+                        "name": "Task",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Task"
+                            "$ref": "#/definitions/main.shortTask"
                         }
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/tasks/{id}": {
+            "get": {
+                "description": "Gets all tasks with specified ID",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "getTaskByID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID to get",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {}
@@ -41,14 +66,11 @@
         }
     },
     "definitions": {
-        "main.Task": {
+        "main.shortTask": {
             "type": "object",
             "properties": {
                 "complete": {
                     "type": "boolean"
-                },
-                "id": {
-                    "type": "integer"
                 },
                 "title": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,11 +1,9 @@
 basePath: /
 definitions:
-  main.Task:
+  main.shortTask:
     properties:
       complete:
         type: boolean
-      id:
-        type: integer
       title:
         type: string
     type: object
@@ -22,16 +20,33 @@ paths:
       - '*/*'
       description: Adds new task at the end of database
       parameters:
-      - description: The task to add
+      - description: Task to add
         in: body
-        name: task
+        name: Task
         required: true
         schema:
-          $ref: '#/definitions/main.Task'
+          $ref: '#/definitions/main.shortTask'
       produces:
       - application/json
       responses: {}
       summary: postTasks
+      tags:
+      - root
+  /tasks/{id}:
+    get:
+      consumes:
+      - '*/*'
+      description: Gets all tasks with specified ID
+      parameters:
+      - description: ID to get
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses: {}
+      summary: getTaskByID
       tags:
       - root
 schemes:

--- a/handler.go
+++ b/handler.go
@@ -15,8 +15,28 @@ func getHealth(c *gin.Context) {
 func getTasks(c *gin.Context) {
 }
 
-// TODO: Implement getTasksByID
+// getTaskByID godoc
+// @Summary getTaskByID
+// @Description Gets all tasks with specified ID
+// @Tags root
+// @Param id path int true "ID to get"
+// @Accept */*
+// @Produce json
+// @Router /tasks/{id} [get]
 func getTaskByID(c *gin.Context) {
+	searchedID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, err)
+	}
+
+	foundTask, err := getTaskByID_sql(searchedID)
+
+	if err != nil {
+		c.IndentedJSON(http.StatusNotFound, err)
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, foundTask)
 }
 
 // TODO: add func getTasksByComplete
@@ -26,12 +46,12 @@ func getTaskByID(c *gin.Context) {
 // @Description Adds new task at the end of database
 // @Tags root
 // @RequestBody required
-// @Param task body Task true "The task to add"
+// @Param Task body shortTask true "Task to add"
 // @Accept */*
 // @Produce json
 // @Router /tasks [POST]
 func postTask(c *gin.Context) {
-	var newTask Task
+	var newTask shortTask
 
 	if err := c.BindJSON(&newTask); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err)

--- a/task.go
+++ b/task.go
@@ -5,3 +5,8 @@ type Task struct {
 	Title    string `json:"title"`
 	Complete bool   `json:"complete"`
 }
+
+type shortTask struct {
+	Title    string `json:"title"`
+	Complete bool   `json:"complete"`
+}

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -1,17 +1,30 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
 )
 
 // TODO: add func getTasks_sql
 
-// TODO: add func getTaskByID_sql
+// Returns task in SQL database with specified ID
+func getTaskByID_sql(id int) (Task, error) {
+	var foundTask Task
+
+	row := db.QueryRow("SELECT * FROM tasks WHERE id = ?", id)
+	if err := row.Scan(&foundTask.ID, &foundTask.Title, &foundTask.Complete); err != nil {
+		if err == sql.ErrNoRows {
+			return foundTask, fmt.Errorf("taskByID %d: no such task", id)
+		}
+		return foundTask, fmt.Errorf("taskByID %d: %v", id, err)
+	}
+	return foundTask, nil
+}
 
 // TODO: add func getTasksByComplete_sql
 
 // Adds task to the end of SQL database
-func postTask_sql(tsk Task) (int64, error) {
+func postTask_sql(tsk shortTask) (int64, error) {
 	result, err := db.Exec("INSERT INTO tasks (Title, Complete) VALUES (?, ?)", tsk.Title, tsk.Complete)
 	if err != nil {
 		return 0, fmt.Errorf("error: %v", err)


### PR DESCRIPTION
This branch transfers the getTaskByID function from the Go to the SQL database, as well as creating a new "shortTask" type for better integration into Swagger for all functions going forward. postTask was updated to use shortTask. 