### PR TITLE
getTasks() transfer to SQL

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -17,6 +17,20 @@ const docTemplate = `{
     "basePath": "{{.BasePath}}",
     "paths": {
         "/tasks": {
+            "get": {
+                "description": "Gets all tasks in database",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "getTasks",
+                "responses": {}
+            },
             "post": {
                 "description": "Adds new task at the end of database",
                 "consumes": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13,6 +13,20 @@
     "basePath": "/",
     "paths": {
         "/tasks": {
+            "get": {
+                "description": "Gets all tasks in database",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "getTasks",
+                "responses": {}
+            },
             "post": {
                 "description": "Adds new task at the end of database",
                 "consumes": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,6 +15,16 @@ info:
   version: "1.0"
 paths:
   /tasks:
+    get:
+      consumes:
+      - '*/*'
+      description: Gets all tasks in database
+      produces:
+      - application/json
+      responses: {}
+      summary: getTasks
+      tags:
+      - root
     post:
       consumes:
       - '*/*'

--- a/handler.go
+++ b/handler.go
@@ -11,8 +11,20 @@ import (
 func getHealth(c *gin.Context) {
 }
 
-// TODO: Implement getTasks
+// getTasks godoc
+// @Summary getTasks
+// @Description Gets all tasks in database
+// @Tags root
+// @Accept */*
+// @Produce json
+// @Router /tasks [get]
 func getTasks(c *gin.Context) {
+	taskList, err := getTasks_sql()
+	if err != nil {
+		c.IndentedJSON(http.StatusInternalServerError, err)
+	}
+
+	c.IndentedJSON(http.StatusOK, taskList)
 }
 
 // getTaskByID godoc

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -5,7 +5,27 @@ import (
 	"fmt"
 )
 
-// TODO: add func getTasks_sql
+// Returns all tasks in SQL database
+func getTasks_sql() ([]Task, error) {
+	var taskList []Task
+
+	tasks, err := db.Query("SELECT * FROM tasks")
+	if err != nil {
+		return taskList, err
+	}
+
+	for tasks.Next() {
+		var tsk Task
+
+		if err := tasks.Scan(&tsk.ID, &tsk.Title, &tsk.Complete); err != nil {
+			return taskList, err
+		}
+
+		taskList = append(taskList, tsk)
+	}
+
+	return taskList, nil
+}
 
 // Returns task in SQL database with specified ID
 func getTaskByID_sql(id int) (Task, error) {


### PR DESCRIPTION
Branch creates the getTasks_sql function, which is called to by getTasks and reads the SQL database. Allows users to get all tasks from the SQL database returned in a JSON format. Swagger implementation also added for this feature.

<img width="1904" alt="Screenshot 2023-07-03 at 11 16 54 AM" src="https://github.com/PeytonBoggs/todo-list-API/assets/129628668/d958833f-7395-414c-b889-785f83b277ea">
