### PR TITLE
deleteTasks() transfer to SQL

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -41,6 +41,20 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {}
+            },
+            "delete": {
+                "description": "Deletes all tasks",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "deleteTasks",
+                "responses": {}
             }
         },
         "/tasks/{id}": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -37,6 +37,20 @@
                     }
                 ],
                 "responses": {}
+            },
+            "delete": {
+                "description": "Deletes all tasks",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "deleteTasks",
+                "responses": {}
             }
         },
         "/tasks/{id}": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,6 +15,16 @@ info:
   version: "1.0"
 paths:
   /tasks:
+    delete:
+      consumes:
+      - '*/*'
+      description: Deletes all tasks
+      produces:
+      - application/json
+      responses: {}
+      summary: deleteTasks
+      tags:
+      - root
     post:
       consumes:
       - '*/*'

--- a/handler.go
+++ b/handler.go
@@ -72,6 +72,24 @@ func postTask(c *gin.Context) {
 func putTasks(c *gin.Context) {
 }
 
+// deleteTasks godoc
+// @Summary deleteTasks
+// @Description Deletes all tasks
+// @Tags root
+// @Accept */*
+// @Produce json
+// @Router /tasks [DELETE]
+func deleteTasks(c *gin.Context) {
+	rowsAffected, err := deleteTasks_sql()
+	if err != nil {
+		c.IndentedJSON(http.StatusNotFound, err)
+		return
+	}
+
+	message := strconv.Itoa(int(rowsAffected)) + " tasks deleted"
+	c.IndentedJSON(http.StatusOK, message)
+}
+
 // TODO: Implement deleteTask
 func deleteTask(c *gin.Context) {
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	router.GET("/tasks/:id", getTaskByID)
 	router.POST("/tasks", postTask)
 	router.PUT("/tasks/:id", putTasks)
+	router.DELETE("/tasks", deleteTasks)
 	router.DELETE("/tasks/:id", deleteTask)
 
 	router.Run("localhost:8080")

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -39,4 +39,29 @@ func postTask_sql(tsk shortTask) (int64, error) {
 
 // TODO: add func putTasks_sql
 
+// Deletes all tasks in SQL database
+func deleteTasks_sql() (int64, error) {
+	result, err := db.Exec("DELETE FROM tasks")
+	if err != nil {
+		return 0, err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	_, err = db.Exec("TRUNCATE TABLE tasks")
+	if err != nil {
+		return 0, err
+	}
+
+	_, err = db.Exec("ALTER TABLE tasks AUTO_INCREMENT = 1")
+	if err != nil {
+		return 0, err
+	}
+
+	return rowsAffected, nil
+}
+
 // TODO: add func deleteTask_sql


### PR DESCRIPTION
Branch adds deleteTasks_sql() function, which with deleteTasks(), deletes all tasks in the SQL database. This function also resets the auto-incremented ID to 1, so that all new tasks after delete has been called will start with an ID of 1.

<img width="1904" alt="Screenshot 2023-07-03 at 11 18 55 AM" src="https://github.com/PeytonBoggs/todo-list-API/assets/129628668/e176be5d-ba6b-4005-b471-4eaf09c6b3c9">
