### PR TITLE
patchCompleteByID() transfer to SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ For all commands,
         --header "Content-Type: application/json" \
         --request "DELETE"
 
+### Patch complete by ID:
+    curl http://localhost:8080/tasks/<ID> \
+        --include \
+        --header "Content-Type: application/json" \
+        --request "PATCH"
+
 ### Get table:
 
 In SQL logged-in terminal, having set the database,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -89,6 +89,29 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {}
+            },
+            "patch": {
+                "description": "Toggles complete at specified ID",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "patchCompleteByID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "The specified ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
             }
         }
     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -85,6 +85,29 @@
                     }
                 ],
                 "responses": {}
+            },
+            "patch": {
+                "description": "Toggles complete at specified ID",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "patchCompleteByID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "The specified ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
             }
         }
     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -65,6 +65,22 @@ paths:
       summary: getTaskByID
       tags:
       - root
+    patch:
+      consumes:
+      - '*/*'
+      description: Toggles complete at specified ID
+      parameters:
+      - description: The specified ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses: {}
+      summary: patchCompleteByID
+      tags:
+      - root
 schemes:
 - http
 swagger: "2.0"

--- a/handler.go
+++ b/handler.go
@@ -96,3 +96,28 @@ func deleteTaskByID(c *gin.Context) {
 	message := strconv.Itoa(int(rowsAffected)) + " task deleted"
 	c.IndentedJSON(http.StatusOK, message)
 }
+
+// patchCompleteByID godoc
+// @Summary patchCompleteByID
+// @Description Toggles complete at specified ID
+// @Tags root
+// @Param id path int true "The specified ID"
+// @Accept */*
+// @Produce json
+// @Router /tasks/{id} [PATCH]
+func patchCompleteByID(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, err)
+		return
+	}
+
+	rowsAffected, err := patchCompleteByID_sql(id)
+	if err != nil {
+		c.IndentedJSON(http.StatusNotFound, err)
+		return
+	}
+
+	message := strconv.Itoa(int(rowsAffected)) + " task toggled"
+	c.IndentedJSON(http.StatusOK, message)
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	router.POST("/tasks", postTask)
 	router.PUT("/tasks/:id", putTasks)
 	router.DELETE("/tasks/:id", deleteTaskByID)
+	router.PATCH("/tasks/:id", patchCompleteByID)
 
 	router.Run("localhost:8080")
 }

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -52,3 +52,18 @@ func deleteTaskByID_sql(id int) (int64, error) {
 
 	return rowsAffected, nil
 }
+
+// Toggles the complete boolean of the task with input id in SQL database
+func patchCompleteByID_sql(id int) (int64, error) {
+	result, err := db.Exec("UPDATE tasks SET complete = CASE WHEN complete = true THEN false WHEN complete = false THEN true END WHERE id = (?)", id)
+	if err != nil {
+		return 0, err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	return rowsAffected, nil
+}


### PR DESCRIPTION
This branch creates a new function, patchCompleteByID, and along with patchCompleteByID_sql, this function toggles the status of the complete boolean for the task of the specified ID. If the task's complete boolean is set to true, it changes it to false, and vice versa. Swagger documentation has also been added for this function.

![Screenshot 2023-07-05 at 10 50 36 AM](https://github.com/PeytonBoggs/todo-list-API/assets/129628668/914d55a4-3047-4395-8bdf-338cec16fe48)
