### PR TITLE
getTasksByTitle() transfer to SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ For all commands,
 ### Get task by ID:
     curl http://localhost:8080/tasks/<ID>
 
+### Get tasks by Title:
+    curl http://localhost:8080/tasks/title/{title}
+
 ### Post task:
     curl http://localhost:8080/tasks \
         --include \

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,6 +43,31 @@ const docTemplate = `{
                 "responses": {}
             }
         },
+        "/tasks/title/{title}": {
+            "get": {
+                "description": "Gets all tasks whose title includes the specified string",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "getTasksByTitle",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The specified string",
+                        "name": "title",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/tasks/{id}": {
             "get": {
                 "description": "Gets all tasks with specified ID",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -39,6 +39,31 @@
                 "responses": {}
             }
         },
+        "/tasks/title/{title}": {
+            "get": {
+                "description": "Gets all tasks whose title includes the specified string",
+                "consumes": [
+                    "*/*"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "root"
+                ],
+                "summary": "getTasksByTitle",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The specified string",
+                        "name": "title",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/tasks/{id}": {
             "get": {
                 "description": "Gets all tasks with specified ID",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -65,6 +65,23 @@ paths:
       summary: getTaskByID
       tags:
       - root
+  /tasks/title/{title}:
+    get:
+      consumes:
+      - '*/*'
+      description: Gets all tasks whose title includes the specified string
+      parameters:
+      - description: The specified string
+        in: path
+        name: title
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses: {}
+      summary: getTasksByTitle
+      tags:
+      - root
 schemes:
 - http
 swagger: "2.0"

--- a/handler.go
+++ b/handler.go
@@ -96,3 +96,23 @@ func deleteTaskByID(c *gin.Context) {
 	message := strconv.Itoa(int(rowsAffected)) + " task deleted"
 	c.IndentedJSON(http.StatusOK, message)
 }
+
+// getTasksByTitle godoc
+// @Summary getTasksByTitle
+// @Description Gets all tasks whose title includes the specified string
+// @Tags root
+// @Param title path string true "The specified string"
+// @Accept */*
+// @Produce json
+// @Router /tasks/title/{title} [get]
+func getTasksByTitle(c *gin.Context) {
+	title := c.Param("title")
+
+	taskList, err := getTasksByTitle_sql(title)
+	if err != nil {
+		c.IndentedJSON(http.StatusNotFound, err)
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, taskList)
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	router.GET("/health", getHealth)
 	router.GET("/tasks", getTasks)
 	router.GET("/tasks/:id", getTaskByID)
+	router.GET("/tasks/title/:title", getTasksByTitle)
 	router.POST("/tasks", postTask)
 	router.PUT("/tasks/:id", putTasks)
 	router.DELETE("/tasks/:id", deleteTaskByID)

--- a/tasks-repository.go
+++ b/tasks-repository.go
@@ -52,3 +52,24 @@ func deleteTaskByID_sql(id int) (int64, error) {
 
 	return rowsAffected, nil
 }
+
+func getTasksByTitle_sql(title string) ([]Task, error) {
+	var taskList []Task
+
+	tasks, err := db.Query("SELECT * FROM tasks WHERE title LIKE (?)", "%"+title+"%")
+	if err != nil {
+		return taskList, err
+	}
+
+	for tasks.Next() {
+		var tsk Task
+
+		if err := tasks.Scan(&tsk.ID, &tsk.Title, &tsk.Complete); err != nil {
+			return taskList, err
+		}
+
+		taskList = append(taskList, tsk)
+	}
+
+	return taskList, nil
+}


### PR DESCRIPTION
This branch creates a new function, getTasksByTitle, which along with getTasksByTitle_sql, searches the SQL database for any tasks with a title that include the input string. For example, if you input the string "be", the function might return the tasks "Get out of bed" or "Be productive". Swagger support has also been added for this function.

![Screenshot 2023-07-05 at 11 46 31 AM](https://github.com/PeytonBoggs/todo-list-API/assets/129628668/5c9b1904-de65-4055-b62f-26d97c8940bb)
